### PR TITLE
LUN-1371: minimized the number of queries when fetching cms pages

### DIFF
--- a/robots/helpers.py
+++ b/robots/helpers.py
@@ -104,6 +104,19 @@ def get_sitemap(site, protocol):
         try:
             if callable(sitemap):
                 sitemap = sitemap()
+            # page is 1 by default for get_urls method
+            page = 1
+            # iterate through cms pages and set homepage when found in order
+            #   to not execute expensive queries just to re-fetch it for
+            #   each root page
+            homepage_pk = None
+            site_pages = sitemap.paginator.page(page).object_list
+            for page in site_pages:
+                if not homepage_pk:
+                    if page.is_home():
+                        homepage_pk = page.pk
+                else:
+                    page.home_pk_cache = homepage_pk
             urls.extend(sitemap.get_urls(site=site, protocol=protocol))
         except:
             pass


### PR DESCRIPTION
- since a site can only have one home page, there is no need for
  the rest of the pages to check if they are a homepage or not, once
  the home page was found
